### PR TITLE
Use `#![no_std]`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,4 +13,4 @@ keywords = ["memory-management"]
 
 [dependencies]
 log = "0.4"
-nonmax = "0.5"
+nonmax = { version = "0.5", default-features = false }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,10 +1,18 @@
 // offset-allocator/src/lib.rs
 
+#![no_std]
 #![doc = include_str!("../README.md")]
 #![deny(unsafe_code)]
 #![warn(missing_docs)]
 
-use std::fmt::{Debug, Display, Formatter, Result as FmtResult};
+extern crate alloc;
+
+#[cfg(test)]
+extern crate std;
+
+use alloc::vec;
+use alloc::vec::Vec;
+use core::fmt::{Debug, Display, Formatter, Result as FmtResult};
 
 use log::debug;
 use nonmax::{NonMaxU16, NonMaxU32};


### PR DESCRIPTION
Allows this crate to be used even when `std` is unavailable.