### PR TITLE
Use `u32` for `offset` field of `Allocation`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,7 +78,7 @@ where
     NI: NodeIndex,
 {
     /// The location of this allocation within the buffer.
-    pub offset: NI,
+    pub offset: u32,
     /// The node index associated with this allocation.
     metadata: NI::NonMax,
 }
@@ -291,7 +291,7 @@ where
 
         let node = &mut self.nodes[node_index.to_usize()];
         Some(Allocation {
-            offset: NI::from_u32(node.data_offset),
+            offset: node.data_offset,
             metadata: node_index,
         })
     }


### PR DESCRIPTION
The `offset` field is a unit offset, not a node index.